### PR TITLE
skip user authentication on flats index and show pages

### DIFF
--- a/app/controllers/flats_controller.rb
+++ b/app/controllers/flats_controller.rb
@@ -1,5 +1,6 @@
 class FlatsController < ApplicationController
   before_action :find_flat, only: [:show, :create]
+  skip_before_action :authenticate_user!, only: [:index, :show]
 
   def index
     @search = params[:search]


### PR DESCRIPTION
skip_before_action added to flats controller so that user only asked to sign in once they have gone through to flat show page and clicked on book. Else they can decide to login from the home page.